### PR TITLE
Remove use of the Date object and join the date string

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,7 @@ const r = require("request")
  * @returns {Promise<String|Request>} Promise object represents an instance of request() from the request library for the image, or String with image URL
  */
 exports.getImage = async function request(options) {
-    const dateString = (function createForamttedDate() {
-        const date = new Date(...options.date);
-        return date.getFullYear() + "/" + (date.getMonth()) + "/" + date.getDate();
-    })();
+    const dateString = options.date.join('/');
 
     console.log(dateString)
 


### PR DESCRIPTION
The Date object returns values in a way that is not needed for this implementation. The best way of doing this is to join the date array provided.

`[2021, 12, 19]` -> `2021/12/19`